### PR TITLE
remove interpreter name and add flexibility for multiple databases

### DIFF
--- a/workflow/snakefile/microbiome_analysis
+++ b/workflow/snakefile/microbiome_analysis
@@ -71,19 +71,19 @@ rule calculate_alpha_diversity:
         alpha_diversity_csv = 'output/{sample}/bracken_output/{sample}_alpha_diversity.csv'
     shell:
         '''
-        python alpha_diversity.py \
+        alpha_diversity.py \
             -f {input.bracken_output} -a BP >> {output.alpha_diversity_csv}
 
-        python alpha_diversity.py  \
+        alpha_diversity.py  \
             -f {input.bracken_output} -a Sh >> {output.alpha_diversity_csv}
 
-        python alpha_diversity.py  \
+        alpha_diversity.py  \
             -f {input.bracken_output} -a F >> {output.alpha_diversity_csv}
 
-        python alpha_diversity.py \
+        alpha_diversity.py \
             -f {input.bracken_output} -a Si >> {output.alpha_diversity_csv}
 
-        python alpha_diversity.py  \
+        alpha_diversity.py  \
             -f {input.bracken_output} -a ISi >> {output.alpha_diversity_csv}
 
         {params.alpha_stats_cleanup_script} {input.bracken_output} {params.temp_alpha_diversity_csv}
@@ -114,7 +114,7 @@ rule generate_sample_krona_plots:
         krona_html = 'output/{sample}/{sample}_krona.html'
     shell:
         '''
-        python kreport2krona.py \
+        kreport2krona.py \
             --report-file {input.bracken_report} --output {output.b_txt}
 
         ktImportText \

--- a/workflow/snakefile/pathogen_analysis
+++ b/workflow/snakefile/pathogen_analysis
@@ -1,3 +1,4 @@
+import os
 import sys
 #### relative path from service-script ####
 pe_samples = glob_wildcards('staging/pe_reads/{sample}_R{read_num}.fastq.gz').sample
@@ -42,7 +43,7 @@ rule generate_sample_krona_plots:
         krona_html = 'output/{sample}/{sample}_krona.html'
     shell:
         '''
-        python kreport2krona.py \
+        kreport2krona.py \
             --report-file {input.k2report} --output {output.k_text}
 
         ktImportText \

--- a/workflow/snakefile/pathogen_analysis
+++ b/workflow/snakefile/pathogen_analysis
@@ -1,4 +1,3 @@
-import os
 import sys
 #### relative path from service-script ####
 pe_samples = glob_wildcards('staging/pe_reads/{sample}_R{read_num}.fastq.gz').sample

--- a/workflow/snakefile/pe_fastq_processing
+++ b/workflow/snakefile/pe_fastq_processing
@@ -1,4 +1,3 @@
-import os
 import sys
 #### running from service-script ####
 samples = glob_wildcards("staging/pe_reads/{sample}_R{read_num}.fastq.gz").sample

--- a/workflow/snakefile/pe_fastq_processing
+++ b/workflow/snakefile/pe_fastq_processing
@@ -1,3 +1,4 @@
+import os
 import sys
 #### running from service-script ####
 samples = glob_wildcards("staging/pe_reads/{sample}_R{read_num}.fastq.gz").sample
@@ -5,7 +6,8 @@ read_nums = glob_wildcards("staging/pe_reads/{sample}_R{read_num}.fastq.gz").rea
 msg = 'snakefile command recieved - PAIRED END FASTQ PROCESSING \n'
 sys.stderr.write(msg)
 configfile: "config.json"
-ruleorder: fastqc_raw_reads > hisat2_remove_host_dna > fastqc_on_host_removed_reads > classify_with_kraken
+ruleorder: fastqc_raw_reads > hisat2_remove_host_dna > fastqc_on_host_removed_reads #> classify_with_kraken
+database = "/vol/patric3/metagenome_dbs/kraken2"
 
 rule all:
     input:
@@ -94,6 +96,7 @@ rule classify_with_kraken:
         clean_r1 = 'output/{sample}/hisat2_results/{sample}_host_removed_R1.fastq.gz',
         clean_r2 = 'output/{sample}/hisat2_results/{sample}_host_removed_R2.fastq.gz'
     params:
+        database = database_path,
         kraken_dir = 'output/{sample}/kraken_output'
     output:
         k2_output = 'output/{sample}/kraken_output/{sample}_k2_output.txt',
@@ -102,7 +105,7 @@ rule classify_with_kraken:
         '''
         mkdir -p {params.kraken_dir}
 
-        kraken2 --db /vol/patric3/metagenome_dbs/kraken2 \
+        kraken2 --db {params.database} \
             --threads 12 \
             --minimum-hit-groups 3 \
             --report-minimizer-data \

--- a/workflow/snakefile/pe_fastq_processing
+++ b/workflow/snakefile/pe_fastq_processing
@@ -5,7 +5,7 @@ read_nums = glob_wildcards("staging/pe_reads/{sample}_R{read_num}.fastq.gz").rea
 msg = 'snakefile command recieved - PAIRED END FASTQ PROCESSING \n'
 sys.stderr.write(msg)
 configfile: "config.json"
-ruleorder: fastqc_raw_reads > hisat2_remove_host_dna > fastqc_on_host_removed_reads #> classify_with_kraken
+ruleorder: fastqc_raw_reads > hisat2_remove_host_dna > fastqc_on_host_removed_reads > classify_with_kraken
 database = "/vol/patric3/metagenome_dbs/kraken2"
 
 rule all:

--- a/workflow/snakefile/se_fastq_processing
+++ b/workflow/snakefile/se_fastq_processing
@@ -5,6 +5,7 @@ msg = 'snakefile command recieved - SINGLE END FASTQ PROCESSING'
 sys.stderr.write(msg)
 configfile: "config.json"
 ruleorder: fastqc_raw_reads > hisat2_remove_host_dna > fastqc_on_host_removed_reads > classify_with_kraken
+database = "/vol/patric3/metagenome_dbs/kraken2"
 
 rule all:
     input:

--- a/workflow/snakefile/se_fastq_processing
+++ b/workflow/snakefile/se_fastq_processing
@@ -85,6 +85,7 @@ rule classify_with_kraken:
     input:
         clean_se = 'output/{sample}/hisat2_results/{sample}_host_removed.fastq.gz'
     params:
+        database = database_path,
         kraken_dir = 'output/{sample}/kraken_output'
     output:
         k2_output = 'output/{sample}/kraken_output/{sample}_k2_output.txt',
@@ -93,7 +94,7 @@ rule classify_with_kraken:
         '''
         mkdir -p {params.kraken_dir}
 
-        kraken2 --db /vol/patric3/metagenome_dbs/kraken2 \
+        kraken2 --db {params.database} \
             --threads 12 \
             --minimum-hit-groups 3 \
             --report-minimizer-data \


### PR DESCRIPTION
Hello Bob, 
I removed the interpreter commands. I added the database path as a variable. If we decide to support multiple databases, we can set this variable according to the user parameters in the config file.
Nicole 