### PR TITLE
remove Krona plot(s) from 16S anlaysis 

### DIFF
--- a/workflow/snakefile/16s_analysis
+++ b/workflow/snakefile/16s_analysis
@@ -16,7 +16,6 @@ workflow_dir = config["workflow_dir"]
 rule_all_list = [
     expand('output/{sample}/bracken_output/{sample}_bracken_output.txt', sample = samples),
     expand('output/{sample}/{sample}_alpha_diversity.csv', sample = samples),
-    expand('output/{sample}_krona.html', sample = samples),
     expand('output/{sample}_sankey.html', sample = samples),
     expand('clean_up/{sample}_sankey_files', sample = samples),
     'output/alpha_diversity.csv',
@@ -27,16 +26,17 @@ rule_all_list = [
 ## this adds felxiblity for one sample (1 single end fq or just one paired end, 2 fqs)
 ## multisample comparison and visualizations will either fail or be redundant if only one sample present
 if len(se_samples) == 1 and len(pe_samples) == 0 or len(se_samples) == 0 and len(pe_samples) == 2:
-    ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > generate_sample_krona_plots > generate_sankey_plots > multiqc 
-    msg = "preforming analysis for only one sample - DOES NOT INCLUDE multisample_comparison.html, multisample_krona.html \n"
+    # ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > generate_sample_krona_plots > generate_sankey_plots > multiqc 
+    ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > generate_sankey_plots > multiqc 
+    msg = "preforming analysis for only one sample - DOES NOT INCLUDE multisample_comparison.html \n"
     sys.stderr.write(msg)
 else:
-    ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > calculate_beta_diversity > generate_sample_krona_plots > generate_multisample_krona_plots > generate_sankey_plots > multisample_comp_table > clean_up_multisample_html_files > multiqc
-    msg = "preforming analysis for multiple samples - INCLUDES multisample_comparison.html, multisample_krona.html \n"
+    # ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > calculate_beta_diversity > generate_sample_krona_plots > generate_multisample_krona_plots > generate_sankey_plots > multisample_comp_table > clean_up_multisample_html_files > multiqc
+    ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > calculate_beta_diversity > generate_sankey_plots > multisample_comp_table > clean_up_multisample_html_files > multiqc
+    msg = "preforming analysis for multiple samples - INCLUDES multisample_comparison.html \n"
     sys.stderr.write(msg)
     rule_all_list.append('output/multisample_comparison.html')
     rule_all_list.append('clean_up/multisample_comparison_files')
-    rule_all_list.append('output/multisample_krona.html')
     rule_all_list.append('output/beta_diversity.csv')
 
 
@@ -137,28 +137,6 @@ rule calculate_beta_diversity:
         python3 {params.beta_stats_cleanup_script} {params.temp_beta_diversity_csv} {output.beta_diversity_csv} {output.beta_diversity_html}
         '''
 
-rule generate_sample_krona_plots:
-    input:
-        bracken_report = 'output/{sample}/bracken_output/{sample}_bracken_report.txt'
-    output:
-        krona_html = 'output/{sample}_krona.html'
-    shell:
-        '''
-        ktImportTaxonomy -t 5 -m 3 \
-            {input.bracken_report} \
-            -o {output.krona_html}
-        '''
-rule generate_multisample_krona_plots:
-    input:
-        bracken_reports = set(expand('output/{sample}/bracken_output/{sample}_bracken_report.txt', sample = samples))
-    output:
-        set_krona_plot = 'output/multisample_krona.html'
-    shell:
-        '''
-        ktImportTaxonomy -t 5 -m 3 \
-            {input.bracken_reports} \
-            -o {output.set_krona_plot}
-        '''
 
 rule generate_sankey_plots:
     input:

--- a/workflow/snakefile/16s_analysis
+++ b/workflow/snakefile/16s_analysis
@@ -26,12 +26,10 @@ rule_all_list = [
 ## this adds felxiblity for one sample (1 single end fq or just one paired end, 2 fqs)
 ## multisample comparison and visualizations will either fail or be redundant if only one sample present
 if len(se_samples) == 1 and len(pe_samples) == 0 or len(se_samples) == 0 and len(pe_samples) == 2:
-    # ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > generate_sample_krona_plots > generate_sankey_plots > multiqc 
     ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > generate_sankey_plots > multiqc 
     msg = "preforming analysis for only one sample - DOES NOT INCLUDE multisample_comparison.html \n"
     sys.stderr.write(msg)
 else:
-    # ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > calculate_beta_diversity > generate_sample_krona_plots > generate_multisample_krona_plots > generate_sankey_plots > multisample_comp_table > clean_up_multisample_html_files > multiqc
     ruleorder: bracken_abundance_estimation > calculate_alpha_diversity > merge_alpha_diversity_stats > calculate_beta_diversity > generate_sankey_plots > multisample_comp_table > clean_up_multisample_html_files > multiqc
     msg = "preforming analysis for multiple samples - INCLUDES multisample_comparison.html \n"
     sys.stderr.write(msg)

--- a/workflow/snakefile/wrapper.py
+++ b/workflow/snakefile/wrapper.py
@@ -71,7 +71,7 @@ def post_processing_check(dict_samples, output_dir):
     incomplete = []
     for sample_name in dict_samples:
         # check for problematic Kraken results
-        krona_path = f"{output_dir}/{sample_name}_krona.html"
+        krona_path = f"{output_dir}/{sample_name}_sankey.html"
         if os.path.isfile(krona_path) == True:
             msg = f"{sample_name}"
             complete.append(msg)


### PR DESCRIPTION
Hello Bob,
This PR removes the krona plot from 16S analysis as discussed. Two files are impacted:

- 16S snakefile: Remove all lines related to Krona plot generation
- wrapper: Change the file check at the end of analysis to Sankey diagram rather than Krona plot.

I will submit another PR bringing back the Krona plot I sort out how to make reliable Krona plots with the SILVA and GreenGenes databases.
Thank you,
Nicole 