### PR TITLE
fixing sample ID R1 issue

### DIFF
--- a/tests/silva_paired_16S.json
+++ b/tests/silva_paired_16S.json
@@ -13,7 +13,7 @@
         {
             "title": "Epithelial-derived IL-23 is a driver of oral mucosal inflammatory disease",
             "srr_accession": "SRR26127838",
-            "sample_id": "SRR26127838"
+            "sample_id": "SRR26127838_R1"
         }
     ]
 }


### PR DESCRIPTION
Hello Bob, 
if you could put this intro production. This fix will step R1 in the sample id's confusing the error handling that checks the results and is incorrectly marking jobs as failed.
Files changed:
workflow/snakefile/wrapper.py: parses the sample ids from config.json rather than using the glob method of like the snakefiles. Line 101 was the real problem but this will avoid any potential ambiguity. 
tests/silva_paired_16S.json: added R1 to sample id 
As always, thank you!,
Nicole 