### PR TITLE
Removing "." from ".fastq.gz" and ".fq.gz"

### DIFF
--- a/workflow/snakefile/wrapper.py
+++ b/workflow/snakefile/wrapper.py
@@ -10,7 +10,7 @@ import subprocess
 
 def check_input_fastqs(input_dir, filename, files_to_zip):
     input_path = f"{input_dir}/{filename}"
-    if input_path.endswith(".fastq.gz") or input_path.endswith(".fq.gz"):
+    if input_path.endswith("fastq.gz") or input_path.endswith("fq.gz"):
         return input_path
     
     elif input_path.endswith(".fastq") or input_path.endswith(".fq"):


### PR DESCRIPTION
Hello,
This change add flexibility to user input paths by removing the "." from the file path check for zipping. This is in response to an user ticket where their fastq was "_fastq.gz".
Please reach out with any questions,
Nicole 